### PR TITLE
[tests] set activity types for pull_request event

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,7 @@ on:
     tags:
     - '!*'
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test-unit:


### PR DESCRIPTION
The default types are provided by default, but I'd like to make sure this is consistent in the case it changes in the future.

Docs: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-event-pull_request